### PR TITLE
Board name

### DIFF
--- a/.github/workflows/create-board.yaml
+++ b/.github/workflows/create-board.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Generate Gerber Files
         run: |
-          bash hellen-one/kicad/bin/export.sh hellen88bmw
+          bash hellen-one/kicad/bin/export.sh
 
       - name: 1. Build Docker
         run: |

--- a/kicad/bin/export.sh
+++ b/kicad/bin/export.sh
@@ -1,14 +1,11 @@
 #!/bin/env bash
 
-if [ -z "$1" ]; then
-  echo "Pass file name without extension"
-  exit 1
-fi
-
 # Get path of script so we can call python scripts
 DIR=$(dirname $0)
 
-IN="$1"
+. revision.txt
+
+IN="$BOARD_PREFIX$BOARD_SUFFIX"
 
 # Copy to backup so we can modify before exporting
 cp "$IN.kicad_pcb" "$IN.kicad_pcb.bak"


### PR DESCRIPTION
Fix #308

This assumes revision.txt and the board kicad files are in the directory that export.sh is called from. (Before you could pass a path, e.g. export.sh ../../hellen88bmw)