### PR TITLE
Don't commit files if only date or Kicad version changed

### DIFF
--- a/.github/workflows/create-board.yaml
+++ b/.github/workflows/create-board.yaml
@@ -52,6 +52,11 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         run: |
+          git diff --name-only | while read f; do
+            if [ $(git diff --color=always|perl -wlne 'print $1 if /^\e\[32m\+\e\[m\e\[32m(.*)\e\[m$/' "$f" | grep -vE "Created|Generation|[dD]ate" | wc -l) -eq 0 ]; then
+              git checkout "$f"
+            fi
+          done
           bash hellen-one/bin/gha-commit.sh
 
       - name: Push board files

--- a/bin/gha-commit.sh
+++ b/bin/gha-commit.sh
@@ -6,7 +6,7 @@ git add boards/*
 git reset HEAD *.kicad_pro
 git status
 OUT=$(git commit -am "[skip actions] Auto-generated board" 2>&1) || echo "commit failed, finding out why"
-if echo "$OUT" | grep 'nothing to commit'; then
+if echo "$OUT" | grep 'nothing to commit' || echo "$OUT" | grep 'nothing added to commit'; then
   echo "headers: looks like nothing to commit"
   echo "::set-env name=NOCOMMIT::true"
   exit 0


### PR DESCRIPTION
This is to fix https://github.com/rusefi/rusefi-hardware/issues/223

For this to work, projects using hellen-one will have to update their submodule.

I also excluded Kicad version changes so I could test locally, It will also keep new files from being pushed in the following scenarios:
- The Github Actions runner is updated to a new version of Ubuntu (On Ubuntu, the Kicad version string includes the Ubuntu release)
- If we ever use self-hosted runners, and some runs run on them, and some don't.
- Whenever Kicad is updated (maybe we want to generate new files if this happens?)

I can remove that exclusion if you prefer.